### PR TITLE
PowerPC fixes for the 'rlwimi' instruction and OpenBSD AltiVec detection

### DIFF
--- a/core/cpuinfo.c
+++ b/core/cpuinfo.c
@@ -38,6 +38,10 @@
 # include <exec/exec.h>
 # include <interfaces/exec.h>
 # include <proto/exec.h>
+#elif defined(__OpenBSD__) && defined(__ppc__)
+# include <machine/cpu.h>
+# include <sys/types.h>
+# include <sys/sysctl.h>
 #endif
 
 struct cpuid_regs {
@@ -242,8 +246,15 @@ AG_GetCPUInfo(AG_CPUInfo *_Nonnull cpu)
 
 #if (defined(__APPLE__) || defined(__MACOSX__)) && defined(__ppc__) && \
     !defined(MAC_OS_X_VERSION_10_4)
+	int selectors[2] = { CTL_HW, HW_VECTORUNIT };
+#elif defined(__OpenBSD__) && defined(__ppc__)
+	int selectors[2] = { CTL_MACHDEP, CPU_ALTIVEC };
+#endif
+
+#if (defined(__APPLE__) || defined(__MACOSX__)) && defined(__ppc__) && \
+    !defined(MAC_OS_X_VERSION_10_4) || \
+    (defined(__OpenBSD__) && defined(__ppc__))
 	{
-		int selectors[2] = { CTL_HW, HW_VECTORUNIT };
 		int flag = 0;
 		size_t length = sizeof(flag);
 	

--- a/core/inline_byteswap.h
+++ b/core/inline_byteswap.h
@@ -47,11 +47,11 @@ Uint16
 ag_swap16(Uint16 x)
 # endif
 {
-	Uint16 rv;
+	Uint32 rv;
 	__asm__("rlwimi %0,%2,8,16,23" :
 	        "=&r" (rv) :
 		"0" (x >> 8), "r" (x));
-	return (rv);
+	return (Uint16) (rv);
 }
 #else
 # ifdef AG_INLINE_HEADER


### PR DESCRIPTION
Hi,

I'm building libagar using clang 10 on OpenBSD/macppc and met two issues i've fixed: 

1) The AltiVec runtime detection does not work on OpenBSD

That PR adds support for it by expanding the Mac OS X code, since only the sysctl changes. The non alphabetical headers order is [meant to be this way](https://man.openbsd.org/sysctl.2). 

2) The build failed with:

```
include/agar/core/inline_byteswap.h:50:8: error: unsupported inline asm: input with type 'int' matching output with type 'u_int16_t' (aka 'unsigned short')
                "0" (x >> 8), "r" (x));
```
The 'rlwimi' powerpc instruction [wants a 32-bit integer to work with](https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/assembler/idalangref_rlwimi_rlimi_rotwrd_instrs.html).

So we should use an Uint32 for that operation, but cast the return to Uint16, as seen [there](https://github.com/DCurrent/openbor/pull/188/commits/731d9688779502e37c9b53a02b80f689ece40aac).
